### PR TITLE
ADD: cloc for count_unsafe.py (for RV6, hafnium)

### DIFF
--- a/sandbox-20.04/packages.txt
+++ b/sandbox-20.04/packages.txt
@@ -19,6 +19,7 @@ virt-manager
 libncurses5 libtinfo5
 haskell-platform haskell-stack
 nimf nimf-libhangul
+cloc
 
 fonts-hack-ttf fonts-powerline fonts-dejavu ttf-dejavu fonts-symbola
 texlive-full


### PR DESCRIPTION
https://github.com/Medowhill/rv6/blob/22ef9a99077205e15fa5cee4261bfd3532497d54/count_unsafe.py#L16-L18

RV6와 hafnium에서 count_unsafe.py를 사용하기 위해서 `cloc` 패키지가 필요합니다(재민 님과 상욱 님은 로컬에서 확인하신 것 같습니다).